### PR TITLE
Feat/redirect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,4 +84,4 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: feat/redirect

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,4 +84,4 @@ workflows:
             - build
           filters:
             branches:
-              only: feat/redirect
+              only: master

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -32,43 +32,43 @@ routing_rules:
   - condition:
       key_prefix_equals: help/form-design/binding
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-logic
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/external-apps
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: launch-apps-from-collect
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/itext
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-language
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/workarounds
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-best-practices
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/examples
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-question-types
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/open-street-map
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-question-types/#openmapkit-widget
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/form-design/cascading-selects
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-logic/#filtering-options-in-select-questions
       http_redirect_code: 301
   - condition:
@@ -86,207 +86,225 @@ routing_rules:
   - condition:
       key_prefix_equals: help/form-design
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-design-intro
       http_redirect_code: 301
   # help/*
   - condition:
       key_prefix_equals: help/image-based-forms
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-question-types/#including-images-as-choices
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/verifying-downloaded-files
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: verify-downloads
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/encrypted-forms
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: encrypted-forms
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/faq
     redirect:
-      host_name: docs.opendatakit.org
-      replace_key_with: faq
+      host_name: docs.getodk.org
+      replace_key_with: help
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/training-guides
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: ""
       http_redirect_code: 301
   # use/aggregate/*
   - condition:
       key_prefix_equals: use/aggregate/data-transfer
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: aggregate-data-access
       http_redirect_code: 301
   - condition:
       key_prefix_equals: use/aggregate/deployment-planning
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: aggregate-deployment-planning
       http_redirect_code: 301
   - condition:
       key_prefix_equals: use/aggregate/oauth2-service-account
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: oauth2-service
       http_redirect_code: 301
   - condition:
       key_prefix_equals: use/aggregate/tomcat-install
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: aggregate-tomcat
       http_redirect_code: 301
   - condition:
       key_prefix_equals: use/aggregate
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: aggregate-intro
       http_redirect_code: 301
   # use/briefcase
   - condition:
       key_prefix_equals: use/briefcase
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: briefcase-intro
       http_redirect_code: 301
   # use/build
   - condition:
       key_prefix_equals: use/build
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: build-intro
       http_redirect_code: 301
   # use/collect
   - condition:
       key_prefix_equals: use/collect
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: collect-intro
       http_redirect_code: 301
   # use/form-uploader
   - condition:
       key_prefix_equals: use/form-uploader
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: form-uploader
       http_redirect_code: 301
   # use/sensors/*
   - condition:
       key_prefix_equals: use/sensors
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: printer-widget
       http_redirect_code: 301
   # use/validate
   - condition:
       key_prefix_equals: use/validate
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: validate
       http_redirect_code: 301
   # use/xls
   - condition:
       key_prefix_equals: use/xls
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: xlsform
       http_redirect_code: 301
   # use/2_0_tools
   - condition:
       key_prefix_equals: use/2_0_tools
     redirect:
-      host_name: docs.opendatakit.org
-      replace_key_with: odk2
+      host_name: docs.odk-x.org
+      replace_key_with: ""
       http_redirect_code: 301
   # use
   - condition:
       key_prefix_equals: use
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: ""
       http_redirect_code: 301
   # about/*
   - condition:
       key_prefix_equals: about/deployments
     redirect:
-      host_name: forum.opendatakit.org
+      host_name: forum.getodk.org
       replace_key_with: c/showcase
       http_redirect_code: 301
   - condition:
       key_prefix_equals: about/research
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: community/research
       http_redirect_code: 301
   - condition:
       key_prefix_equals: about/security-and-privacy-statement
     redirect:
-      host_name: docs.opendatakit.org
+      host_name: docs.getodk.org
       replace_key_with: security-privacy
       http_redirect_code: 301
   - condition:
       key_prefix_equals: about/team
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: community
       http_redirect_code: 301      
   - condition:
       key_prefix_equals: about/tools
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: software
       http_redirect_code: 301
   - condition:
       key_prefix_equals: about
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: ""
       http_redirect_code: 301
   # downloads
   - condition:
       key_prefix_equals: download
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: software
       http_redirect_code: 301
   # participate
   - condition:
       key_prefix_equals: participate
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: community
       http_redirect_code: 301
   # software
   - condition:
       key_prefix_equals: software/odk1
     redirect:
-      host_name: opendatakit.org
-      replace_key_with: software/odk
+      host_name: getodk.org
+      replace_key_with: software
       http_redirect_code: 301
   - condition:
       key_prefix_equals: software/odk2
     redirect:
-      host_name: opendatakit.org
-      replace_key_with: software/odk-x
+      host_name: odk-x.org
+      replace_key_with: software
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: software/odk-x
+    redirect:
+      host_name: odk-x.org
+      replace_key_with: software
       http_redirect_code: 301
   - condition:
       key_prefix_equals: help/help-for-hire
     redirect:
-      host_name: opendatakit.org
+      host_name: getodk.org
       replace_key_with: providers
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: help/help-for-hire
+    redirect:
+      host_name: getodk.org
+      replace_key_with: providers
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: community/ecosystem
+    redirect:
+      host_name: getodk.org
+      replace_key_with: community/ecosystem
       http_redirect_code: 301
 
 
 # single page redirects. only use with paths that are not in folder redirects.
 redirects:
   feed/index.html: feed.xml
-  xiframe/index.html: xlsform
+  xiframe/index.html: https://getodk.org/xlsform/


### PR DESCRIPTION
This page is hosted on https://d2siqmzm66w2ph.cloudfront.net/ so the redirects can be tested there, e.g. with https://d2siqmzm66w2ph.cloudfront.net/software/odk-x/

I believe I've tested the key redirects, and they work, but considering that this is quite important to avoid disruption, I would appreciate an extra set of eyes. 

Maybe there are some new redirects that we need that I forgot to add?

Any page on the current opendatakit.org that clearly is only about either ODK or ODK-X should get a redirect. Anything else goes to a [helpful 404 page](https://d2siqmzm66w2ph.cloudfront.net/404) (not so helpful at the moment but will be once Google has indexed them).